### PR TITLE
refactor/7 api consistency improv

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -121,7 +121,7 @@ func showSymbols(ctx context.Context) {
 	exitMesg := rotato.Colorize("(Press Ctrl+C to exit)", rotato.ColorGray, rotato.ColorStyleItalic)
 	for _, symbol := range allSymbols {
 		r := rotato.New(
-			rotato.WithMesg(exitMesg),
+			rotato.WithMessage(exitMesg),
 			rotato.WithPrefix(symbol.s+strings.Repeat(" ", maxLen-len(symbol.s))),
 			rotato.WithContext(ctx),
 			symbol.o,
@@ -145,7 +145,7 @@ func spSimple(ctx context.Context) {
 	r := rotato.New(
 		rotato.WithSpinnerColor(rotato.ColorBrightGreen),
 		rotato.WithPrefix("Simple Task #1"),
-		rotato.WithDoneColorMesg(rotato.ColorBrightGreen, rotato.ColorStyleItalic),
+		rotato.WithDoneMessageColor(rotato.ColorBrightGreen, rotato.ColorStyleItalic),
 		rotato.WithContext(ctx),
 	)
 	r.Start()
@@ -164,7 +164,7 @@ func spConnection(ctx context.Context) {
 	r := rotato.New(
 		rotato.WithSymbolsCircles3(),
 		rotato.WithSpinnerColor(rotato.ColorOrange),
-		rotato.WithMesg("Connecting..."),
+		rotato.WithMessage("Connecting..."),
 		rotato.WithPrefix("S3 Backup"),
 		rotato.WithContext(ctx),
 	)
@@ -213,9 +213,9 @@ func spConnection(ctx context.Context) {
 // spFail simulates a failed connection process.
 func spFail(ctx context.Context) {
 	r := rotato.New(
-		rotato.WithMesg("Trying to connect..."),
+		rotato.WithMessage("Trying to connect..."),
 		rotato.WithPrefix("AWS Server"),
-		rotato.WithFailColorMesg(rotato.ColorBrightRed, rotato.ColorStyleBlink),
+		rotato.WithFailMessageColor(rotato.ColorBrightRed, rotato.ColorStyleBlink),
 		rotato.WithContext(ctx),
 	)
 	r.Start()

--- a/rotato.go
+++ b/rotato.go
@@ -194,7 +194,7 @@ func WithFrequency(d time.Duration) Option {
 // WithWriter returns an option function that sets the spinner writer.
 func WithWriter(w io.Writer) Option {
 	return func(r *Rotato) {
-		r.Writer = w
+		r.writer = w
 	}
 }
 
@@ -234,7 +234,7 @@ type Option func(*Rotato)
 // Rotato represents a CLI spinner animation.
 type Rotato struct {
 	// Output
-	Writer   io.Writer // Output writer
+	writer   io.Writer // Output writer
 	writerMu sync.Mutex
 
 	// Context
@@ -320,7 +320,7 @@ func (r *Rotato) Start() {
 		return
 	}
 
-	hideCursor(r.Writer)
+	hideCursor(r.writer)
 	r.activeMu.Lock()
 	if r.isActive {
 		r.activeMu.Unlock()
@@ -329,7 +329,7 @@ func (r *Rotato) Start() {
 	r.isActive = true
 	r.activeMu.Unlock()
 
-	if isRedirected(r.Writer) && !r.forceInteractive {
+	if isRedirected(r.writer) && !r.forceInteractive {
 		r.render(0)
 		return
 	}
@@ -363,7 +363,7 @@ func (r *Rotato) Start() {
 
 // Done stops the spinner animation.
 func (r *Rotato) Done(mesg ...string) {
-	defer showCursor(r.Writer)
+	defer showCursor(r.writer)
 
 	r.stopSpinner()
 
@@ -383,17 +383,6 @@ func (r *Rotato) Done(mesg ...string) {
 	r.displayMessage(symbol, r.doneMessageColor, finalMesg)
 }
 
-func formatSymbol(symbol, color string) string {
-	if symbol == "" {
-		return ""
-	}
-	if color == "" {
-		return symbol
-	}
-
-	return color + symbol + string(ColorReset)
-}
-
 // Fail fails the spinner animation.
 func (r *Rotato) Fail(mesg ...string) {
 	r.stopSpinner()
@@ -403,6 +392,20 @@ func (r *Rotato) Fail(mesg ...string) {
 	symbol := formatSymbol(r.failSymbol, r.failSymbolColor)
 
 	r.displayMessage(symbol, r.failMessageColor, mesg...)
+}
+
+// SetWriter updates the output destination safely.
+func (r *Rotato) SetWriter(w io.Writer) {
+	r.writerMu.Lock()
+	defer r.writerMu.Unlock()
+	r.writer = w
+}
+
+// Writer returns the current output destination.
+func (r *Rotato) Writer() io.Writer {
+	r.writerMu.Lock()
+	defer r.writerMu.Unlock()
+	return r.writer
 }
 
 // Symbols returns the spinner symbols.
@@ -416,7 +419,7 @@ func (r *Rotato) UpdateMesg(mesg string) {
 	r.message = mesg
 	r.messageUpdate.Unlock()
 	if !isInteractive(r) {
-		_, _ = fmt.Fprintf(r.Writer, "%s\n", mesg)
+		_, _ = fmt.Fprintf(r.writer, "%s\n", mesg)
 	}
 }
 
@@ -433,25 +436,25 @@ func (r *Rotato) UpdatePrefix(mesg string) {
 }
 
 // UpdatePrefixColor changes the color of the prefix.
-func (r *Rotato) UpdatePrefixColor(color ...string) {
-	r.prefixColor = strings.Join(color, "")
+func (r *Rotato) UpdatePrefixColor(c ...Color) {
+	r.prefixColor = joinColors(c...)
 }
 
 // UpdateDoneMesgColor changes the done message shown next to the spinner.
-func (r *Rotato) UpdateDoneMesgColor(mesg ...string) {
-	r.doneMessageColor = strings.Join(mesg, "")
+func (r *Rotato) UpdateDoneMesgColor(c ...Color) {
+	r.doneMessageColor = joinColors(c...)
 }
 
 // UpdateSpinnerColor changes the color of the spinner.
-func (r *Rotato) UpdateSpinnerColor(color ...string) {
-	r.spinnerColor = strings.Join(color, "")
+func (r *Rotato) UpdateSpinnerColor(c ...Color) {
+	r.spinnerColor = joinColors(c...)
 }
 
 // UpdateSymbols updates the spinner symbols.
 func (r *Rotato) UpdateSymbols(opt Option) {
 	r.activeMu.Lock()
+	defer r.activeMu.Unlock()
 	opt(r)
-	r.activeMu.Unlock()
 }
 
 // currentMessage safely constructs and returns the current message.
@@ -491,12 +494,12 @@ func (r *Rotato) display(s string) {
 	r.writerMu.Lock()
 	defer r.writerMu.Unlock()
 
-	if isRedirected(r.Writer) {
-		_, _ = fmt.Fprint(r.Writer, removeANSI(s))
+	if isRedirected(r.writer) {
+		_, _ = fmt.Fprint(r.writer, removeANSI(s))
 		return
 	}
 
-	_, _ = fmt.Fprintf(r.Writer, "%s%s", clearChars, s)
+	_, _ = fmt.Fprintf(r.writer, "%s%s", clearChars, s)
 }
 
 // stopSpinner handles the common logic for stopping the spinner.
@@ -514,7 +517,7 @@ func (r *Rotato) stopSpinner() {
 		return
 	}
 
-	defer showCursor(r.Writer)
+	defer showCursor(r.writer)
 	r.doneChan <- struct{}{}
 }
 
@@ -582,11 +585,24 @@ func (r *Rotato) IsRunning() bool {
 	return r.isActive
 }
 
+// decorateMessage applies all message decorators in order.
 func (r *Rotato) decorateMessage(mesg string) string {
 	for _, d := range r.decorators {
 		mesg = d(mesg)
 	}
 	return mesg
+}
+
+// formatSymbol wraps a symbol with color codes if provided.
+func formatSymbol(symbol, color string) string {
+	if symbol == "" {
+		return ""
+	}
+	if color == "" {
+		return symbol
+	}
+
+	return color + symbol + string(ColorReset)
 }
 
 // removeANSI removes ANSI codes from a given string.
@@ -607,7 +623,7 @@ func New(opt ...Option) *Rotato {
 		doneSymbol: "✓",
 		failSymbol: "✗",
 		symbols:    defaultSymbols,
-		Writer:     os.Stdout,
+		writer:     os.Stdout,
 	}
 	for _, fn := range opt {
 		fn(r)

--- a/rotato.go
+++ b/rotato.go
@@ -202,7 +202,7 @@ func WithForceInteractive() Option {
 
 // WithMesgDecorator appends a decorator to transform the spinner message
 // before display.
-func WithMesgDecorator(fn mesgDecorator) Option {
+func WithMesgDecorator(fn MesgDecorator) Option {
 	return func(r *Rotato) {
 		r.decorators = append(r.decorators, fn)
 	}
@@ -215,8 +215,8 @@ func WithContextDoneHandler(handler func(*Rotato, error)) Option {
 	}
 }
 
-// mesgDecorator defines a function that transforms a message string.
-type mesgDecorator func(mesg string) string
+// MesgDecorator defines a function that transforms a message string.
+type MesgDecorator func(mesg string) string
 
 // Option is an option function for the spinner.
 type Option func(*Rotato)
@@ -267,12 +267,12 @@ type Rotato struct {
 	failSymbol       string // Fail symbol
 	failSymbolColor  string // Fail symbol color
 
-	// decorators holds message decorator functions applied before display.
-	decorators []mesgDecorator
-
 	// Active state
 	isActive bool         // State of the spinner
 	activeMu sync.RWMutex // Mutex for different spinner states
+
+	// decorators holds message decorator functions applied before display.
+	decorators []MesgDecorator
 }
 
 // render displays the current frame and message of the spinner.
@@ -353,9 +353,6 @@ func (r *Rotato) Start() {
 
 // Done stops the spinner animation.
 func (r *Rotato) Done(mesg ...string) {
-	if !r.isActive {
-		return
-	}
 	defer showCursor(r.Writer)
 
 	r.stopSpinner()
@@ -367,7 +364,7 @@ func (r *Rotato) Done(mesg ...string) {
 	case r.doneMessage != "":
 		finalMesg = r.doneMessage
 	default:
-		fmt.Print(clearChars)
+		r.display(clearChars)
 		return
 	}
 
@@ -519,8 +516,14 @@ func (r *Rotato) displayMessage(symbol, color string, mesg ...string) {
 
 	msg := strings.Join(mesg, " ")
 
-	var sb strings.Builder
+	if !isInteractive(r) && !r.forceInteractive {
+		// the leading \n moves us off the "Loading..." line
+		// the trailing \n finishes the log entry
+		r.display("\n" + msg + "\n")
+		return
+	}
 
+	var sb strings.Builder
 	// prefix path
 	if r.prefixMesg != "" {
 		r.buildPrefix(&sb, symbol)
@@ -537,26 +540,26 @@ func (r *Rotato) displayMessage(symbol, color string, mesg ...string) {
 	sb.WriteString(msg)
 	sb.WriteByte('\n')
 
-	// single reset at the end
+	// single reset at end
 	sb.WriteString(string(ColorReset))
-
-	// output path
-	if !isInteractive(r) && !r.forceInteractive {
-		r.display(sb.String())
-		return
-	}
 
 	r.display(sb.String())
 }
 
 func (r *Rotato) buildPrefix(sb *strings.Builder, symbol string) {
-	if r.prefixMesg == "" {
-		return
+	// prefix
+	if r.prefixColor != "" {
+		sb.WriteString(r.prefixColor)
+	}
+	sb.WriteString(r.prefixMesg)
+	if r.prefixColor != "" {
+		sb.WriteString(string(ColorReset))
 	}
 
-	sb.WriteString(r.prefixMesg)
-	sb.WriteByte(' ')
+	// delimiter
+	sb.WriteString(r.delimiterColor + r.delimiter + string(ColorReset))
 
+	// symbol
 	if symbol != "" {
 		sb.WriteString(symbol)
 		sb.WriteByte(' ')

--- a/rotato.go
+++ b/rotato.go
@@ -72,18 +72,26 @@ import (
 	"time"
 )
 
-// WithMesg returns an option function that sets the spinner message.
-func WithMesg(s string) Option {
+// WithMessage returns an option function that sets the spinner message.
+func WithMessage(s string) Option {
 	return func(r *Rotato) {
 		r.message = s
 	}
 }
 
-// WithMesgColor returns an option function that sets the spinner message
+// WithMessageColor returns an option function that sets the spinner message
 // color.
-func WithMesgColor(c ...Color) Option {
+func WithMessageColor(c ...Color) Option {
 	return func(r *Rotato) {
 		r.messageColor = joinColors(c...)
+	}
+}
+
+// WithMessageDecorator appends a decorator to transform the spinner message
+// before display.
+func WithMessageDecorator(fn MesgDecorator) Option {
+	return func(r *Rotato) {
+		r.decorators = append(r.decorators, fn)
 	}
 }
 
@@ -102,70 +110,6 @@ func WithPrefixColor(c ...Color) Option {
 	}
 }
 
-// WithDoneMesg returns an option function that sets the spinner done message.
-func WithDoneMesg(mesg string) Option {
-	return func(r *Rotato) {
-		r.doneMessage = mesg
-	}
-}
-
-// WithDoneSymbol returns an option function that sets the spinner stop symbol.
-func WithDoneSymbol(symbol string) Option {
-	return func(r *Rotato) {
-		r.doneSymbol = symbol
-	}
-}
-
-// WithDoneColorMesg returns an option function that sets the done message
-// color.
-func WithDoneColorMesg(c ...Color) Option {
-	return func(r *Rotato) {
-		r.doneMessageColor = joinColors(c...)
-	}
-}
-
-// WithDoneColorSymbol sets the combined color(s) for the completion symbol.
-func WithDoneColorSymbol(c ...Color) Option {
-	return func(r *Rotato) {
-		r.doneSymbolColor = joinColors(c...)
-	}
-}
-
-// WithFailSymbol returns an option function that sets the spinner fail symbol.
-func WithFailSymbol(symbol string) Option {
-	return func(r *Rotato) {
-		r.failSymbol = symbol
-	}
-}
-
-// WithFailColorMesg returns an option function that sets the fail message
-// color.
-func WithFailColorMesg(c ...Color) Option {
-	return func(r *Rotato) {
-		r.failMessageColor = joinColors(c...)
-	}
-}
-
-func WithFailColorSymbol(c ...Color) Option {
-	return func(r *Rotato) {
-		r.failSymbolColor = joinColors(c...)
-	}
-}
-
-// WithSpinnerColor returns an option function that sets the spinner color.
-func WithSpinnerColor(c ...Color) Option {
-	return func(r *Rotato) {
-		r.spinnerColor = joinColors(c...)
-	}
-}
-
-// WithFrequency returns an option function that sets the spinner frequency.
-func WithFrequency(d time.Duration) Option {
-	return func(r *Rotato) {
-		r.frequency = d
-	}
-}
-
 // WithDelimiter returns an option function that sets the spinner delimiter.
 func WithDelimiter(s string) Option {
 	return func(r *Rotato) {
@@ -178,6 +122,72 @@ func WithDelimiter(s string) Option {
 func WithDelimiterColor(c ...Color) Option {
 	return func(r *Rotato) {
 		r.delimiterColor = joinColors(c...)
+	}
+}
+
+// WithSpinnerColor returns an option function that sets the spinner color.
+func WithSpinnerColor(c ...Color) Option {
+	return func(r *Rotato) {
+		r.spinnerColor = joinColors(c...)
+	}
+}
+
+// WithDoneMessage returns an option function that sets the spinner done message.
+func WithDoneMessage(mesg string) Option {
+	return func(r *Rotato) {
+		r.doneMessage = mesg
+	}
+}
+
+// WithDoneSymbol returns an option function that sets the spinner stop symbol.
+func WithDoneSymbol(symbol string) Option {
+	return func(r *Rotato) {
+		r.doneSymbol = symbol
+	}
+}
+
+// WithDoneMessageColor returns an option function that sets the done message
+// color.
+func WithDoneMessageColor(c ...Color) Option {
+	return func(r *Rotato) {
+		r.doneMessageColor = joinColors(c...)
+	}
+}
+
+// WithDoneSymbolColor sets the combined color(s) for the completion symbol.
+func WithDoneSymbolColor(c ...Color) Option {
+	return func(r *Rotato) {
+		r.doneSymbolColor = joinColors(c...)
+	}
+}
+
+// WithFailSymbol returns an option function that sets the spinner fail symbol.
+func WithFailSymbol(symbol string) Option {
+	return func(r *Rotato) {
+		r.failSymbol = symbol
+	}
+}
+
+// WithFailMessageColor returns an option function that sets the fail message
+// color.
+func WithFailMessageColor(c ...Color) Option {
+	return func(r *Rotato) {
+		r.failMessageColor = joinColors(c...)
+	}
+}
+
+// WithFailSymbolColor returns an option function that sets the fail symbol
+// color.
+func WithFailSymbolColor(c ...Color) Option {
+	return func(r *Rotato) {
+		r.failSymbolColor = joinColors(c...)
+	}
+}
+
+// WithFrequency returns an option function that sets the spinner frequency.
+func WithFrequency(d time.Duration) Option {
+	return func(r *Rotato) {
+		r.frequency = d
 	}
 }
 
@@ -452,7 +462,7 @@ func (r *Rotato) currentMessage() string {
 	r.messageUpdate.RLock()
 	defer r.messageUpdate.RUnlock()
 
-	return r.messageColor + r.message + string(ColorReset)
+	return Colorize(r.message, Color(r.messageColor))
 }
 
 // currentFrame returns the spinner frame for the given iteration.

--- a/rotato_test.go
+++ b/rotato_test.go
@@ -13,8 +13,8 @@ func TestSpinnerOutput(t *testing.T) {
 	mesg := "Testing"
 	r := New(
 		WithWriter(&buf),
-		WithMesg(mesg),
-		WithDoneMesg("Done"),
+		WithMessage(mesg),
+		WithDoneMessage("Done"),
 		WithFrequency(10*time.Millisecond),
 	)
 
@@ -39,7 +39,7 @@ func TestSpinnerState(t *testing.T) {
 		WithWriter(&buf),
 		WithFrequency(10*time.Millisecond),
 		WithSymbols([]string{"-", "\\", "|", "/"}...),
-		WithDoneMesg("Stopped"),
+		WithDoneMessage("Stopped"),
 	)
 	r.Start()
 	time.Sleep(20 * time.Millisecond)
@@ -62,8 +62,8 @@ func TestSpinnerMessageUpdate(t *testing.T) {
 	r := New(
 		WithWriter(&buf),
 		WithFrequency(10*time.Millisecond),
-		WithMesg("Initial"),
-		WithDoneMesg("Done"),
+		WithMessage("Initial"),
+		WithDoneMessage("Done"),
 	)
 	r.Start()
 	time.Sleep(20 * time.Millisecond)
@@ -138,8 +138,8 @@ func TestContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	r := New(
 		WithWriter(&buf),
-		WithMesg(mesg),
-		WithDoneMesg("Done"),
+		WithMessage(mesg),
+		WithDoneMessage("Done"),
 		WithContext(ctx),
 		WithForceInteractive(),
 		WithFrequency(10*time.Millisecond),
@@ -161,8 +161,8 @@ func TestContextCancelThenDone(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	r := New(
 		WithWriter(&buf),
-		WithMesg("Running..."),
-		WithDoneMesg("Completed"),
+		WithMessage("Running..."),
+		WithDoneMessage("Completed"),
 		WithContext(ctx),
 		WithForceInteractive(),
 		WithFrequency(10*time.Millisecond),
@@ -191,7 +191,7 @@ func TestContextTimeoutStopsSpinner(t *testing.T) {
 
 	r := New(
 		WithWriter(&buf),
-		WithMesg("Timing out..."),
+		WithMessage("Timing out..."),
 		WithContext(ctx),
 		WithForceInteractive(),
 		WithFrequency(5*time.Millisecond),
@@ -215,7 +215,7 @@ func TestStartWithPreCancelledContext(t *testing.T) {
 
 	r := New(
 		WithWriter(&buf),
-		WithMesg(mesg),
+		WithMessage(mesg),
 		WithContext(ctx),
 		WithFrequency(5*time.Millisecond),
 		WithForceInteractive(),
@@ -305,7 +305,7 @@ func TestMesgDecorator(t *testing.T) {
 	suffix := "::suffix"
 
 	r := New(
-		WithMesgDecorator(func(mesg string) string {
+		WithMessageDecorator(func(mesg string) string {
 			return prefix + mesg + suffix
 		}),
 	)

--- a/rotato_test.go
+++ b/rotato_test.go
@@ -238,12 +238,13 @@ func TestStartWithPreCancelledContext(t *testing.T) {
 
 func TestDisplayMessage(t *testing.T) {
 	tests := []struct {
-		name     string
-		symbol   string
-		color    string
-		msg      []string
-		prefix   string
-		expected string
+		name      string
+		symbol    string
+		delimiter string
+		color     string
+		msg       []string
+		prefix    string
+		expected  string
 	}{
 		{
 			name:     "symbol + message",
@@ -253,25 +254,27 @@ func TestDisplayMessage(t *testing.T) {
 			expected: "✓ done\n",
 		},
 		{
-			name:     "color applied",
+			name:     "color applied - ANSI stripped on redirect",
 			symbol:   "✓",
 			color:    "\x1b[32m",
 			msg:      []string{"ok"},
 			expected: "✓ ok\n",
 		},
 		{
-			name:     "no symbol",
-			color:    "",
-			msg:      []string{"hello"},
-			expected: "hello\n",
+			name:      "no symbol",
+			delimiter: "--",
+			color:     "",
+			msg:       []string{"hello"},
+			expected:  "hello\n",
 		},
 		{
-			name:     "prefix overrides symbol position",
-			symbol:   "✓",
-			color:    "",
-			msg:      []string{"done"},
-			prefix:   "step1",
-			expected: "step1 ✓ done\n",
+			name:      "prefix overrides symbol position",
+			symbol:    "✓",
+			color:     "",
+			delimiter: NBSP,
+			msg:       []string{"done"},
+			prefix:    "step1",
+			expected:  "step1" + NBSP + "✓ done\n",
 		},
 	}
 
@@ -279,10 +282,13 @@ func TestDisplayMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 
-			r := &Rotato{
-				Writer:     buf,
-				prefixMesg: tt.prefix,
-			}
+			r := New(
+				WithWriter(buf),
+				WithDelimiter(tt.delimiter),
+				WithDoneSymbol(tt.symbol),
+				WithPrefix(tt.prefix),
+				WithForceInteractive(), // bypass isInteractive early-return
+			)
 
 			r.displayMessage(tt.symbol, tt.color, tt.msg...)
 

--- a/term.go
+++ b/term.go
@@ -34,7 +34,7 @@ func showCursor(output io.Writer) {
 
 // isInteractive checks if the output is interactive.
 func isInteractive(r *Rotato) bool {
-	return !isRedirected(r.Writer)
+	return !isRedirected(r.writer)
 }
 
 // isRedirected checks if the provided output writer is redirected.


### PR DESCRIPTION
- **refactor(core): improve `non-interactive` logs and prefix rendering**
- **refactor(rotato): normalize `message` opt naming**
- **refactor(rotato): make `writer` private**

fixes #7
