### PR TITLE
refactor(context): remove stored `context` from `rotato`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ full: test lint
 
 # Run tests
 test:
-	@echo '>> Testing'
-	@go test -v ./...
+	@echo '>> Testing go test ./... -race'
+	@go test ./... -race
 	@echo
 
 # Run tests for a specific function
 testfn:
 	@echo '>> Testing function $(FN)'
-	@go test -run $(FN) ./...
+	@go test -run $(FN) ./... -race
 
 testrace:
 	@echo '>> Testing'
@@ -34,5 +34,11 @@ demo:
 # run all example
 all:
 	@go run example/demo.go -all
+
+ci: lint
+	go mod tidy
+	git diff --exit-code
+	go build ./...
+	go test -race ./...
 
 .PHONY: test testfn lint full

--- a/example/demo.go
+++ b/example/demo.go
@@ -41,7 +41,7 @@ type Flags struct {
 var (
 	greenBold   = rotato.NewColor(rotato.StyleBold, rotato.FgBrightGreen)
 	greenItalic = rotato.NewColor(rotato.FgBrightGreen, rotato.StyleItalic)
-	hint        = rotato.FgGray.With(rotato.StyleItalic).Sprint("(ctrl+c to exit)")
+	hint        = rotato.StyleDim.With(rotato.StyleItalic).Sprint("(ctrl+c to exit)")
 )
 
 //nolint:gosec // deterministic demo seed
@@ -71,14 +71,13 @@ func pause(ctx context.Context, d time.Duration) error {
 // sceneSimple shows the most basic spinner usage: start, wait, done.
 func sceneSimple(ctx context.Context) {
 	r := rotato.New(
-		rotato.WithContext(ctx),
 		rotato.WithPrefix("Fetching config"),
 		rotato.WithPrefixColor(rotato.StyleItalic),
 		rotato.WithSpinnerColor(rotato.FgBrightCyan),
 		rotato.WithDoneSymbolColor(greenBold),
 		rotato.WithDoneMessageColor(greenItalic),
 	)
-	r.Start()
+	r.Start(ctx)
 
 	if err := pause(ctx, 1500*time.Millisecond); err != nil {
 		r.Fail("Aborted")
@@ -91,7 +90,6 @@ func sceneSimple(ctx context.Context) {
 // by updating its message and symbol set as work progresses.
 func sceneMultiStep(ctx context.Context) {
 	r := rotato.New(
-		rotato.WithContext(ctx),
 		rotato.WithSymbolsCircles6(),
 		rotato.WithSpinnerColor(rotato.FgOrange),
 		rotato.WithPrefix("S3 backup"),
@@ -100,7 +98,7 @@ func sceneMultiStep(ctx context.Context) {
 		rotato.WithDoneSymbolColor(greenBold),
 		rotato.WithDoneMessageColor(rotato.StyleBold),
 	)
-	r.Start()
+	r.Start(ctx)
 
 	// Phase 1 - connect
 	if err := pause(ctx, 1600*time.Millisecond); err != nil {
@@ -136,7 +134,6 @@ func sceneMultiStep(ctx context.Context) {
 // sceneError shows the failure path.
 func sceneError(ctx context.Context) {
 	r := rotato.New(
-		rotato.WithContext(ctx),
 		rotato.WithPrefix("AWS Health Check"),
 		rotato.WithSymbolsPipe(),
 		rotato.WithSpinnerColor(rotato.FgBlue.With(rotato.StyleBold)),
@@ -144,7 +141,7 @@ func sceneError(ctx context.Context) {
 		rotato.WithFailSymbolColor(rotato.StyleBold, rotato.FgBrightRed),
 		rotato.WithFailMessageColor(rotato.FgBrightRed),
 	)
-	r.Start()
+	r.Start(ctx)
 
 	if err := pause(ctx, 2*time.Second); err != nil {
 		r.Fail("aborted by user")
@@ -163,7 +160,6 @@ func sceneCountdown(ctx context.Context) {
 	defer cancel()
 
 	r := rotato.New(
-		rotato.WithContext(ctx),
 		rotato.WithPrefix("Shutting Down"),
 		rotato.WithPrefixColor(rotato.StyleBold),
 		rotato.WithMessage("in"),
@@ -189,7 +185,7 @@ func sceneCountdown(ctx context.Context) {
 			return color.With(rotato.StyleItalic).Sprintf("in %.0fs...", remaining.Seconds())
 		}),
 	)
-	r.Start()
+	r.Start(ctx)
 
 	// Wait for the internal deadline; the spinner stops itself when ctx fires.
 	<-ctx.Done()
@@ -214,7 +210,6 @@ func sceneElapse(ctx context.Context) {
 
 	// Step 1: Download
 	download := rotato.New(
-		rotato.WithContext(ctx),
 		rotato.WithSpinnerColor(rotato.FgBrightGreen),
 		rotato.WithDoneSymbol("\u203A"),
 		rotato.WithDoneSymbolColor(rotato.FgBrightCyan),
@@ -224,7 +219,7 @@ func sceneElapse(ctx context.Context) {
 		rotato.WithPrefixDecorator(formatter), // elapsed
 		rotato.WithMessage("Downloading chunks..."),
 	)
-	download.Start()
+	download.Start(ctx)
 	if err := pause(ctx, 3*time.Second); err != nil {
 		download.Fail("Aborted")
 		return
@@ -233,7 +228,6 @@ func sceneElapse(ctx context.Context) {
 
 	// Step 2: Verify
 	verify := rotato.New(
-		rotato.WithContext(ctx),
 		rotato.WithDoneSymbol("\u203A"),
 		rotato.WithDoneSymbolColor(rotato.FgBrightYellow),
 		rotato.WithSymbolsCircles7(),
@@ -243,7 +237,7 @@ func sceneElapse(ctx context.Context) {
 		rotato.WithPrefixDecorator(formatter), // elapsed
 		rotato.WithMessage("Verifying checksum..."),
 	)
-	verify.Start()
+	verify.Start(ctx)
 	if err := pause(ctx, 3*time.Second); err != nil {
 		verify.Fail("Aborted")
 		return
@@ -252,7 +246,6 @@ func sceneElapse(ctx context.Context) {
 
 	// Step 3: Extract
 	extract := rotato.New(
-		rotato.WithContext(ctx),
 		rotato.WithSpinnerStyle("growvert"),
 		rotato.WithSpinnerColor(greenBold),
 		rotato.WithFrequency(140*time.Millisecond),
@@ -261,7 +254,7 @@ func sceneElapse(ctx context.Context) {
 		rotato.WithMessage("Extracting files..."),
 		rotato.WithDoneSymbolColor(greenBold),
 	)
-	extract.Start()
+	extract.Start(ctx)
 	if err := pause(ctx, 2*time.Second); err != nil {
 		extract.Fail("Aborted")
 		return
@@ -287,14 +280,13 @@ func showSymbols(ctx context.Context) {
 
 	for _, sp := range rotato.Spinners() {
 		r := rotato.New(
-			rotato.WithContext(ctx),
 			rotato.WithPrefix(padRight(sp.Name, maxLen)),
 			rotato.WithSpinnerStyle(sp.Name),
 			rotato.WithMessage(hint),
 			rotato.WithDoneSymbolColor(greenBold),
 			rotato.WithFailSymbolColor(rotato.StyleBold, rotato.FgBrightRed),
 		)
-		r.Start()
+		r.Start(ctx)
 
 		if err := pause(ctx, 1400*time.Millisecond); err != nil {
 			r.Fail("interrupted")
@@ -359,14 +351,13 @@ func showByGroup(ctx context.Context, g rotato.SpinnerGroup) {
 
 func runRotato(ctx context.Context, sp rotato.SpinnerStyle, name string) {
 	r := rotato.New(
-		rotato.WithContext(ctx),
 		rotato.WithSymbols(sp.Frames...),
 		rotato.WithPrefix(name),
 		rotato.WithMessage(hint),
 		rotato.WithDoneSymbolColor(greenBold),
 		rotato.WithFailSymbolColor(rotato.StyleBold, rotato.FgBrightRed),
 	)
-	r.Start()
+	r.Start(ctx)
 
 	if err := pause(ctx, 1500*time.Millisecond); err != nil {
 		r.Fail("interrupted")

--- a/rotato.go
+++ b/rotato.go
@@ -214,13 +214,6 @@ func WithWriter(w io.Writer) Option {
 	}
 }
 
-// WithContext sets the context for the spinner.
-func WithContext(ctx context.Context) Option {
-	return func(r *Rotato) {
-		r.ctx = ctx
-	}
-}
-
 // WithForceInteractive forces the spinner to run in interactive mode.
 func WithForceInteractive() Option {
 	return func(r *Rotato) {
@@ -248,7 +241,6 @@ type Rotato struct {
 	writerMu sync.Mutex
 
 	// Context
-	ctx            context.Context
 	ctxDoneHandler func(r *Rotato, err error)
 
 	// for Testing
@@ -310,7 +302,7 @@ func (r *Rotato) render(current int) {
 }
 
 // Start starts the spinning animation in a goroutine.
-func (r *Rotato) Start() {
+func (r *Rotato) Start(ctx context.Context) {
 	if !isInteractive(r) && !r.forceInteractive {
 		r.activeMu.Lock()
 		defer r.activeMu.Unlock()
@@ -350,9 +342,9 @@ func (r *Rotato) Start() {
 			select {
 			case <-r.doneChan:
 				return
-			case <-r.ctx.Done():
+			case <-ctx.Done():
 				if r.ctxDoneHandler != nil {
-					r.ctxDoneHandler(r, r.ctx.Err())
+					r.ctxDoneHandler(r, ctx.Err())
 				}
 
 				r.stopSpinner()
@@ -654,14 +646,14 @@ func CountdownDecorator(d time.Duration) string {
 // DimCountdownDecorator formats remaining duration as dimmed seconds text.
 // It displays remaining time in seconds (ss left).
 func DimCountdownDecorator(d time.Duration) string {
-	return FgGray.With(StyleItalic).Sprintf("(%.0fs left)", d.Seconds())
+	return StyleDim.With(StyleItalic).Sprintf("(%.0fs left)", d.Seconds())
 }
 
 // DimElapsedDecorator formats elapsed duration as dimmed mm:ss.
 func DimElapsedDecorator(d time.Duration) string {
 	m := int(d.Minutes())
 	s := int(d.Seconds()) % 60
-	return FgGray.Sprintf("+%02d:%02d", m, s)
+	return StyleDim.Sprintf("+%02d:%02d", m, s)
 }
 
 // ElapsedDecorator formats elapsed duration as mm:ss.
@@ -688,10 +680,6 @@ func New(opt ...Option) *Rotato {
 	}
 	for _, fn := range opt {
 		fn(r)
-	}
-
-	if r.ctx == nil {
-		r.ctx = context.Background()
 	}
 
 	return r

--- a/rotato_test.go
+++ b/rotato_test.go
@@ -3,7 +3,9 @@ package rotato
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -18,7 +20,8 @@ func TestSpinnerOutput(t *testing.T) {
 		WithFrequency(10*time.Millisecond),
 	)
 
-	r.Start()
+	ctx := context.Background()
+	r.Start(ctx)
 	time.Sleep(50 * time.Millisecond)
 	r.Done()
 
@@ -41,7 +44,10 @@ func TestSpinnerState(t *testing.T) {
 		WithSymbols([]string{"-", "\\", "|", "/"}...),
 		WithDoneMessage("Stopped"),
 	)
-	r.Start()
+
+	ctx := context.Background()
+	r.Start(ctx)
+
 	time.Sleep(20 * time.Millisecond)
 	// verify that the spinner state is true.
 	if !r.isActive {
@@ -65,11 +71,17 @@ func TestSpinnerMessageUpdate(t *testing.T) {
 		WithMessage("Initial"),
 		WithDoneMessage("Done"),
 	)
-	r.Start()
+
+	ctx := context.Background()
+	r.Start(ctx)
+
 	time.Sleep(20 * time.Millisecond)
+
 	// Update the message.
 	r.UpdateMesg("Updated")
+
 	time.Sleep(50 * time.Millisecond)
+
 	r.Done()
 
 	out := buf.String()
@@ -81,7 +93,8 @@ func TestSpinnerMessageUpdate(t *testing.T) {
 func TestFailMesg(t *testing.T) {
 	var buf bytes.Buffer
 	r := New(WithWriter(&buf))
-	r.Start()
+	ctx := context.Background()
+	r.Start(ctx)
 	r.Fail("Failed")
 	out := buf.String()
 	if !strings.Contains(out, "Failed") {
@@ -140,14 +153,16 @@ func TestContext(t *testing.T) {
 		WithWriter(&buf),
 		WithMessage(mesg),
 		WithDoneMessage("Done"),
-		WithContext(ctx),
 		WithForceInteractive(),
 		WithFrequency(10*time.Millisecond),
 	)
 
-	r.Start()
+	r.Start(ctx)
+
 	time.Sleep(50 * time.Millisecond)
+
 	cancel()
+
 	time.Sleep(50 * time.Millisecond)
 
 	isActive := r.IsRunning()
@@ -163,14 +178,16 @@ func TestContextCancelThenDone(t *testing.T) {
 		WithWriter(&buf),
 		WithMessage("Running..."),
 		WithDoneMessage("Completed"),
-		WithContext(ctx),
 		WithForceInteractive(),
 		WithFrequency(10*time.Millisecond),
 	)
 
-	r.Start()
+	r.Start(ctx)
+
 	time.Sleep(50 * time.Millisecond)
+
 	cancel()
+
 	time.Sleep(50 * time.Millisecond)
 
 	if r.IsRunning() {
@@ -192,12 +209,11 @@ func TestContextTimeoutStopsSpinner(t *testing.T) {
 	r := New(
 		WithWriter(&buf),
 		WithMessage("Timing out..."),
-		WithContext(ctx),
 		WithForceInteractive(),
 		WithFrequency(5*time.Millisecond),
 	)
 
-	r.Start()
+	r.Start(ctx)
 	time.Sleep(timeout + 50*time.Millisecond)
 
 	isActive := r.IsRunning()
@@ -216,12 +232,11 @@ func TestStartWithPreCancelledContext(t *testing.T) {
 	r := New(
 		WithWriter(&buf),
 		WithMessage(mesg),
-		WithContext(ctx),
 		WithFrequency(5*time.Millisecond),
 		WithForceInteractive(),
 	)
 
-	r.Start()
+	r.Start(ctx)
 	time.Sleep(5 * time.Millisecond)
 
 	isActive := r.IsRunning()
@@ -364,13 +379,12 @@ func TestContextCancelled(t *testing.T) {
 
 	r := New(
 		WithWriter(&buf),
-		WithContext(ctx),
 		WithForceInteractive(),
 		WithContextDoneHandler(func(r *Rotato, err error) {
 			r.Fail(err.Error())
 		}),
 	)
-	r.Start()
+	r.Start(ctx)
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -392,13 +406,12 @@ func TestContextDeadlineExceeded(t *testing.T) {
 	r := New(
 		WithWriter(&buf),
 		WithPrefix("CtxDeadlineExceeded"),
-		WithContext(ctx),
 		WithForceInteractive(),
 		WithContextDoneHandler(func(r *Rotato, err error) {
 			r.Fail(err.Error())
 		}),
 	)
-	r.Start()
+	r.Start(ctx)
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -409,5 +422,113 @@ func TestContextDeadlineExceeded(t *testing.T) {
 
 	if !strings.Contains(got, want) {
 		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
+// TestStopSpinner_NoDeadlockDone is the same scenario but exercises Done
+// instead of Fail.
+func TestStopSpinner_NoDeadlockDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	r := New(
+		WithWriter(io.Discard),
+		WithMessage("Loading..."),
+		WithForceInteractive(),
+	)
+	r.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.Done("Finished!")
+	}()
+
+	select {
+	case <-done:
+		// good.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Done() blocked: stopSpinner deadlock detected (goroutine already exited)")
+	}
+}
+
+// TestRotato_DoneConcurrency tests the data race by firing multiple Done()
+// calls simultaneously.
+func TestRotato_DoneConcurrency(t *testing.T) {
+	var buf bytes.Buffer
+
+	r := &Rotato{
+		writer:           &buf,
+		isActive:         true,
+		doneChan:         make(chan struct{}, 1), // buffered to prevent blocking if read isn't active
+		forceInteractive: true,                   // force it to act like a real terminal
+	}
+
+	const workers = 50
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	// fire 50 goroutines trying to stop the spinner at the exact same time
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			r.Done("Concurrent Done")
+		}()
+	}
+
+	wg.Wait()
+
+	// verify the spinner state was safely transitioned
+	if r.isActive {
+		t.Errorf("expected isActive to be false")
+	}
+
+	// the doneChan should only receive `exactly` one signal, regardless of
+	// how many goroutines called `Done()`
+	if len(r.doneChan) != 1 {
+		t.Errorf("expected doneChan to have exactly 1 item, got %d", len(r.doneChan))
+	}
+}
+
+// TestStopSpinner_DoneFailRace simulates the logical race condition where a context
+// timeout triggers Fail() at the exact same millisecond the deferred Done() fires.
+func TestStopSpinner_DoneFailRace(t *testing.T) {
+	var buf bytes.Buffer
+
+	r := &Rotato{
+		writer:           &buf,
+		isActive:         true,
+		doneChan:         make(chan struct{}, 1),
+		forceInteractive: true,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		r.Fail("Context Timeout")
+	}()
+
+	go func() {
+		defer wg.Done()
+		r.Done("Graceful Exit")
+	}()
+
+	wg.Wait()
+
+	if r.isActive {
+		t.Errorf("expected isActive to be false")
+	}
+
+	if len(r.doneChan) != 1 {
+		t.Errorf("expected doneChan to receive exactly 1 stop signal, got %d", len(r.doneChan))
 	}
 }


### PR DESCRIPTION
fixes #22
